### PR TITLE
omega -> lia

### DIFF
--- a/src/attachable/ALocal.v
+++ b/src/attachable/ALocal.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import Bool.
 Require Import RelationClasses.
 

--- a/src/attachable/AMemory.v
+++ b/src/attachable/AMemory.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/attachable/APFPF.v
+++ b/src/attachable/APFPF.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/attachable/APromiseConsistent.v
+++ b/src/attachable/APromiseConsistent.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/attachable/ATView.v
+++ b/src/attachable/ATView.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/attachable/AThread.v
+++ b/src/attachable/AThread.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import Bool.
 Require Import RelationClasses.
 

--- a/src/drf/ADRF_PF.v
+++ b/src/drf/ADRF_PF.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/ADRF_PF0.v
+++ b/src/drf/ADRF_PF0.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/ADRF_PF1.v
+++ b/src/drf/ADRF_PF1.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/ADRF_PF2.v
+++ b/src/drf/ADRF_PF2.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/ADRF_PF3.v
+++ b/src/drf/ADRF_PF3.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/ADRF_PF4.v
+++ b/src/drf/ADRF_PF4.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/ADRF_PF5.v
+++ b/src/drf/ADRF_PF5.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/AMapping.v
+++ b/src/drf/AMapping.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/APredStep.v
+++ b/src/drf/APredStep.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/ASingleDRF_PF.v
+++ b/src/drf/ASingleDRF_PF.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/DRF_PF.v
+++ b/src/drf/DRF_PF.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/DRF_PF0.v
+++ b/src/drf/DRF_PF0.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/Mapping.v
+++ b/src/drf/Mapping.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/Pred.v
+++ b/src/drf/Pred.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/PredStep.v
+++ b/src/drf/PredStep.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/drf/Race.v
+++ b/src/drf/Race.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/drf/ReorderPromises2.v
+++ b/src/drf/ReorderPromises2.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/drf/SingleDRF_PF.v
+++ b/src/drf/SingleDRF_PF.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/gopt/AssertInsertion.v
+++ b/src/gopt/AssertInsertion.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/invariant/Invariant.v
+++ b/src/invariant/Invariant.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/invariant/PFCertify.v
+++ b/src/invariant/PFCertify.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 Require Import Coq.Lists.ListDec Decidable.
 

--- a/src/invariant/PFCommon.v
+++ b/src/invariant/PFCommon.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/invariant/PFStep.v
+++ b/src/invariant/PFStep.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/lang/Cell.v
+++ b/src/lang/Cell.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 Require Import Decidable.
 Require Import Coq.Lists.ListDec.

--- a/src/lang/Configuration.v
+++ b/src/lang/Configuration.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/lang/Local.v
+++ b/src/lang/Local.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import Bool.
 Require Import RelationClasses.
 

--- a/src/lang/Memory.v
+++ b/src/lang/Memory.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/lang/MemoryDomain.v
+++ b/src/lang/MemoryDomain.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/lang/MemoryFacts.v
+++ b/src/lang/MemoryFacts.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/lang/Progress.v
+++ b/src/lang/Progress.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/lang/TView.v
+++ b/src/lang/TView.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/lang/Thread.v
+++ b/src/lang/Thread.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import Bool.
 Require Import RelationClasses.
 

--- a/src/lang/View.v
+++ b/src/lang/View.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 Require Import Coq.Lists.ListDec Decidable.
 

--- a/src/pf/APF.v
+++ b/src/pf/APF.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/pf/APFSingle.v
+++ b/src/pf/APFSingle.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/pf/PF.v
+++ b/src/pf/PF.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/pf/PFSingle.v
+++ b/src/pf/PFSingle.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From Paco Require Import paco.

--- a/src/promotion/Promotion.v
+++ b/src/promotion/Promotion.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/promotion/PromotionDef.v
+++ b/src/promotion/PromotionDef.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/promotion/PromotionProgress.v
+++ b/src/promotion/PromotionProgress.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/promotion/SimCommon.v
+++ b/src/promotion/SimCommon.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/promotion/SimThreadOther.v
+++ b/src/promotion/SimThreadOther.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/promotion/SimThreadPromotion.v
+++ b/src/promotion/SimThreadPromotion.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/prop/LowerPromises.v
+++ b/src/prop/LowerPromises.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 Require Import Coq.Lists.ListDec Decidable.
 

--- a/src/prop/MemoryMerge.v
+++ b/src/prop/MemoryMerge.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/prop/MemoryReorder.v
+++ b/src/prop/MemoryReorder.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/prop/MemorySplit.v
+++ b/src/prop/MemorySplit.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/prop/PFConsistent.v
+++ b/src/prop/PFConsistent.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/prop/PromiseConsistent.v
+++ b/src/prop/PromiseConsistent.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 
 From sflib Require Import sflib.

--- a/src/prop/ReorderPromise.v
+++ b/src/prop/ReorderPromise.v
@@ -1,4 +1,3 @@
-Require Import Omega.
 Require Import RelationClasses.
 Require Import Bool.
 

--- a/src/prop/ReorderPromises.v
+++ b/src/prop/ReorderPromises.v
@@ -1,5 +1,5 @@
-Require Import Omega.
 Require Import RelationClasses.
+Require Import Lia.
 
 From sflib Require Import sflib.
 From Paco Require Import paco.
@@ -49,7 +49,7 @@ Proof.
     esplits; cycle 1.
     + econs 2; eauto.
     + auto.
-    + omega.
+    + lia.
   }
   exploit IH; try exact A23; try refl; eauto. i. des.
   assert (CONS2: Local.promise_consistent (Thread.local e2)).
@@ -65,7 +65,7 @@ Proof.
   { esplits; cycle 1.
     - eauto.
     - econs; eauto.
-    - omega.
+    - lia.
   }
   inversion A12. exploit Thread.step_future; eauto. i. des.
   exploit reorder_nonpf_pf; eauto.
@@ -76,17 +76,17 @@ Proof.
     - eapply rtc_implies; [|exact STEPS2]. apply union_mon. apply Thread.allpf.
   }
   i. des.
-  - subst. esplits; cycle 1; eauto. omega.
+  - subst. esplits; cycle 1; eauto. lia.
   - assert (STEPS: rtcn (@Thread.all_step lang) (S n) e1 e2).
     { econs 2.
       - econs. econs. eauto.
       - eapply rtcn_imply; [|exact A0]. apply union_mon. apply Thread.allpf.
     }
     exploit IH; try exact STEPS; eauto.
-    { omega. }
+    { lia. }
     i. des. esplits; cycle 1; eauto.
     + etrans; eauto.
-    + omega.
+    + lia.
   - assert (STEPS: rtcn (@Thread.all_step lang) (S n) th1' e2).
     { econs 2.
       - econs. econs 1. eauto.
@@ -94,11 +94,11 @@ Proof.
     }
     exploit Thread.step_future; eauto. i. des.
     exploit IH; try exact STEPS; eauto.
-    { omega. }
+    { lia. }
     i. des. esplits; cycle 1.
     + econs 2; eauto.
     + etrans; eauto.
-    + omega.
+    + lia.
 Qed.
 
 Lemma steps_pf_steps
@@ -141,7 +141,7 @@ Proof.
     esplits; cycle 1.
     + econs 2; eauto.
     + auto.
-    + omega.
+    + lia.
   }
   exploit IH; try exact A23; try refl; eauto. i. des.
   assert (CONS2: Local.promise_consistent (Thread.local e2)).
@@ -157,7 +157,7 @@ Proof.
   { esplits; cycle 1.
     - eauto.
     - econs; eauto.
-    - omega.
+    - lia.
   }
   inversion A12. exploit Thread.step_future; eauto. i. des.
   exploit reorder_nonpf_pf; eauto.
@@ -168,17 +168,17 @@ Proof.
     - eapply rtc_implies; [|exact STEPS2]. i. apply tau_union. eapply tau_mon; [|eauto]. apply Thread.allpf.
   }
   i. des.
-  - subst. esplits; cycle 1; eauto. omega.
+  - subst. esplits; cycle 1; eauto. lia.
   - assert (STEPS: rtcn (@Thread.tau_step lang) (S n) e1 e2).
     { econs 2.
       - econs. econs; eauto. unguardH EVENT1. by destruct e2', e0; des.
       - eapply rtcn_imply; [|exact A0]. apply tau_mon. apply Thread.allpf.
     }
     exploit IH; try exact STEPS; eauto.
-    { omega. }
+    { lia. }
     i. des. esplits; cycle 1; eauto.
     + etrans; eauto.
-    + omega.
+    + lia.
   - assert (STEPS: rtcn (@Thread.tau_step lang) (S n) th1' e2).
     { econs 2.
       - econs.
@@ -188,11 +188,11 @@ Proof.
     }
     exploit Thread.step_future; eauto. i. des.
     exploit IH; try exact STEPS; eauto.
-    { omega. }
+    { lia. }
     i. des. esplits; cycle 1.
     + econs 2; eauto. econs; eauto. unguardH EVENT1. by destruct e2', e0; des.
     + etrans; eauto.
-    + omega.
+    + lia.
 Qed.
 
 Lemma tau_steps_pf_tau_steps


### PR DESCRIPTION
Replaced 'omega' w/ 'lia'. It solves compilation errors on Coq 8.14.